### PR TITLE
Add support for variables containing the Delta (Δ) glyph

### DIFF
--- a/litex-mode.el
+++ b/litex-mode.el
@@ -44,6 +44,8 @@
 	arctan cot det hom lim log sec tan arg coth dim liminf max
 	sin tanh)
   "Lisp functions that have their own latex commands.")
+(defvar litex-convert-delta-prefix "Delta-"
+  "If non-nil, convert this to the LaTeX glyph for capital Delta")
 (defvar litex-make-hyphenated-to-subscript t
   "Whether to make the hyphenated variables subscript or not.")
 (defvar litex-latex-maybe-enclose? nil
@@ -129,6 +131,10 @@
 (defun litex-format-variable (var)
   "Format variable VAR for LaTeX."
   (let ((var-str (prin1-to-string var)))
+    (when litex-convert-delta-prefix
+      (while (string-match (concat "\\(^" litex-convert-delta-prefix "\\)\\(.*\\)") var-str)
+	(setq var-str (concat "{\\Delta}"
+			      (match-string 2 var-str)))))
     (if litex-make-hyphenated-to-subscript
 	(while (string-match "\\([^-]+\\)[-]\\(.*\\)" var-str)
 	  (setq var-str (format "%s_{%s}"


### PR DESCRIPTION
Looking for opinions on how we should implement using the Delta (Δ) glyph in variable names, for example denoting a difference in time in the case of `Δt`. The implementation here is not dependent on my previous PR, and might be able to be expanded to support prefixes more generally, but I haven't encountered the need for that in my work. It's also not dependent on the user being able to type Unicode characters.

The prefix is configurable, and the current default should be seen as a placeholder as it contains the `-` character, which generally denotes subscript in this package.

Usage:
```emacs-lisp
(setq Delta-T (- T T-0))
```
Returns:
```latex
{\Delta}T = T - T_{0}
```