### PR TITLE
17 brackets logic

### DIFF
--- a/README.org
+++ b/README.org
@@ -254,7 +254,7 @@ y &=& 2 + 3 + 6 x \\
 |---------------------------------------+------------------------+-----------------------------------------------------------------------------------------|
 | litex-latex-functions                 | '(sin cos tan)         | Lisp functions that have their own latex commands.                                      |
 | litex-make-hyphenated-to-subscript    | t                      | Whether to make the hyphenated variables subscript or not.                              |
-| litex-latex-maybe-enclose?            | nil                    | Enclose latex converted to paran if needed.                                             |
+| litex-latex-always-enclose?           | nil                    | Enclose latex converted to paran all the time.                                 |
 | litex-format-float-string             | "%.3f"                 | Format string to be used by floats.                                                     |
 | litex-format-float-upper-limit        | 1e4                    | Upper limit of what number is formatted as float.                                       |
 | litex-format-float-lower-limit        | 1e-2                   | Lower limit of what number is formatted as float.                                       |

--- a/README.org
+++ b/README.org
@@ -17,35 +17,7 @@ For example if you look at this image you can see how just 1 lines of lisp expre
 
 Not only can it convert lisp expressions to latex, it can also, give intermediate solution steps. Perfect for doing homeworks (as that's what I made it for) :P
 
-
-* Table of contents :TOC:
-- [[#litex-mode][LiTeX mode]]
-- [[#how-to-use][How to Use]]
-- [[#installation][Installation]]
-- [[#usage][Usage]]
-- [[#keybindings][Keybindings]]
-  - [[#setting-keybindings-for-individual-functions][Setting keybindings for individual functions]]
-  - [[#setting-the-whole-litex-provided-keybindings-to-a-prefix-key][Setting the whole litex provided keybindings to a prefix key]]
-  - [[#complete-setup-using-use-package][Complete setup using use-package]]
-- [[#known-problems][Known Problems:]]
-- [[#tips-and-tricks][Tips and Tricks]]
-  - [[#using-case-sensitive-symbols][Using case sensitive symbols]]
-  - [[#slime-integration][Slime integration]]
-  - [[#using-greek-letters][Using Greek letters]]
-- [[#explanation-for-functions][Explanation for functions]]
-  - [[#litex-format-region-last][litex-format-region-last]]
-  - [[#litex-format-region][litex-format-region]]
-  - [[#litex-eval-and-replace][litex-eval-and-replace]]
-  - [[#litex-eval-and-insert][litex-eval-and-insert]]
-  - [[#litex-sexp-to-latex-exp][litex-sexp-to-latex-exp]]
-  - [[#litex-sexp-solve-all-steps][litex-sexp-solve-all-steps]]
-  - [[#litex-increment-number][litex-increment-number]]
-  - [[#litex-exp-to-latex][litex-exp-to-latex]]
-  - [[#litex-exp-in-latex-math][litex-exp-in-latex-math]]
-  - [[#litex-sexp-solve-all-steps-equation][litex-sexp-solve-all-steps-equation]]
-  - [[#litex-sexp-solve-all-steps-eqnarray][litex-sexp-solve-all-steps-eqnarray]]
-- [[#customization][Customization]]
-- [[#contributing][Contributing]]
+NOTE: elisp uses integer calculations so ~(/ 1 2)~ is evaluated to 0, be careful of such pitfalls. For now ~(/ 1.0 2)~ is evaluated as ~0.5~, so I'd recommend using floats when you need floats, and I'm working on optional integration with slime which doesn't have this problem.
 
 * How to Use
 
@@ -60,7 +32,7 @@ Not only can it convert lisp expressions to latex, it can also, give intermediat
 
   Or you can clone this github repo and load it using path.
 
-  Configuration section shows how you can add the load path using ~use-package~.
+  Configuration section shows how you can add the load path using ~use-package~. 
 
 * Usage
     Using ~use-package~ you can do:
@@ -72,18 +44,16 @@ Not only can it convert lisp expressions to latex, it can also, give intermediat
   :hook text-mode)
 #+end_src
 
-Please look through the Keybindings, Functions, Variables, Known problems and the Tips and Tricks to get 100% out of this package.
-
 * Keybindings
-  By default LiTeX-mode doesn't provide any keybindings, but it does have a variable containing bindings for the interactive functions that you can use.
+  By default LiTeX-mode doesn't provide any keybindings, but it does have a variable containing bindings for the interactive functions that you can use. 
 
-
+  
 ** Setting keybindings for individual functions
    You can use ~local-set-key~ to bind individual functions to a key binding.
 #+begin_src emacs-lisp :tangle yes
   (local-set-key (kbd "×") 'litex-insert-or-replace-x)
 #+end_src
-
+   
 ** Setting the whole litex provided keybindings to a prefix key
 
    You can set a prefix key (~C-e~ for me here) like in this example, which makes it so you can for example use ~litex-format-region-last~ using ~C-e f~ using the following in your config. In some cases you might have to unset key ~C-e~ because it's used to goto end of line, I'm replacing that because I don't use it (as ~End~ key does the same).
@@ -91,7 +61,7 @@ Please look through the Keybindings, Functions, Variables, Known problems and th
   (local-set-key (kbd "C-e") litex-key-map)
    #+end_src
 
-
+   
 Contents of litex-key-map are below.
 
   #+begin_src emacs-lisp :tangle yes
@@ -108,7 +78,7 @@ Contents of litex-key-map are below.
 (define-key litex-key-map (kbd "a") 'litex-sexp-solve-all-steps-eqnarray)
   #+end_src
 
-
+  
 ** Complete setup using use-package
    This is the complete setup using use-package, if you installed from melpa. If you installed by cloning the repo, uncomment and provide the load path.
   #+begin_src emacs-lisp :tangle yes
@@ -120,57 +90,6 @@ Contents of litex-key-map are below.
   (local-set-key (kbd "C-e") litex-key-map)
   (local-set-key (kbd "×") 'litex-insert-or-replace-x))
   #+end_src
-
-
-* Known Problems:
-   elisp uses integer calculations so ~(/ 1 2)~ is evaluated to 0, be careful of such pitfalls. For now ~(/ 1.0 2)~ is evaluated as ~0.5~, so I'd recommend using floats when you need floats.
-
-   This problem doesn't exist if you use slime integration.
-
-* Tips and Tricks
-
-** Using case sensitive symbols
-   Inside emacs the symbols are read without case sensitivity, so if you define and variable names ~ABCD~, it'll replace the variable named ~abcd~. To avoid that, specially if you have formula with both lowercase and uppercase symbols you can use this customization.
-
-   #+begin_src emacs-lisp :tangle yes
-  (setq readtable-case :preserve)
-   #+end_src
-
-   NOTE: Currently it only works for elisp, and not for slime integration, I'm searching for a solution with slime.
-
-** Slime integration
-   If you want to do the calculations in your favorite lisp dilect instead of doing it in elisp, or polluting the emacs environment with your variables, or mistakenly messing something up. You can start a slime process with ~slime~ and use that process to evaluate everything.
-
-   You Only need to set this configuration variable true:
-
-#+begin_src emacs-lisp :tangle yes
-(setq litex-use-slime-for-eval t)
-#+end_src
-
-** Using Greek letters
-   Someone who writes in LaTeX will definitely want to include greek letters, so you can use greek letters multiple ways in LiTeX.
-
-*** By double escaping the backslash
-    You can use double escape to escape the backslash so you'll get the variable correct. For example: ~(setq \\alpha 2)~ ⇒ ~\alpha = 2~
-
-*** Using Unicode:
-    You can input unicode greek letters like α,β,γ...,Σ...,Ω, and they'll be rendered fine by LaTeX. For example: ~(setq α 2)~ ⇒ ~α = 2~. Which is the default behavior.
-
-    If you want to use them to input, but still want to use LaTeX equivalent command then you can set ~litex-make-unicode-to-latex~ to true, that'll convert the unicode to LaTeX command. For example: ~(setq α 2)~ ⇒ ~{\alpha} = 2~.
-
-    #+begin_src emacs-lisp :tangle yes
-(setq litex-make-unicode-to-latex t)
-    #+end_src
-
-    As for how to type unicode directly, you can use Compose key in Linux machines, and there is also TeX input method in emacs that lets you do that. If you type ~C-u C-\ TeX <RET>~ for TeX input method then when you type ~\alpha~ emacs will convert it into unicode ~α~.
-
-*** Using conversion from their names
-    By default you can use variables names like ~alpha~ without having it any effect, for example: ~(setq alpha 2)~ ⇒ ~alpha = 2~ but if you set the variable ~litex-make-name-to-latex-glyph~ true then you can just convert normal greek character's names to LaTeX symbols.
-Like: ~(setq alpha 2)~ ⇒ ~{\alpha} = 2~
-
-    #+begin_src emacs-lisp :tangle yes
-(setq litex-make-name-to-latex-glyph t)
-    #+end_src
 
 
 * Explanation for functions
@@ -250,36 +169,29 @@ y &=& 2 + 3 + 6 x \\
 * Customization
   There are lots of variables that define how each of these functions behave.
 
-| Variable Name                         | Default Value          | What it does                                                                            |
-|---------------------------------------+------------------------+-----------------------------------------------------------------------------------------|
-| litex-latex-functions                 | '(sin cos tan)         | Lisp functions that have their own latex commands.                                      |
-| litex-make-hyphenated-to-subscript    | t                      | Whether to make the hyphenated variables subscript or not.                              |
-| litex-latex-maybe-enclose?            | nil                    | Enclose latex converted to paran if needed.                                             |
-| litex-format-float-string             | "%.3f"                 | Format string to be used by floats.                                                     |
-| litex-format-float-upper-limit        | 1e4                    | Upper limit of what number is formatted as float.                                       |
-| litex-format-float-lower-limit        | 1e-2                   | Lower limit of what number is formatted as float.                                       |
-| litex-steps-join-string               | "= "                   | String used for joining strings in steps of a solution.                                 |
-| litex-steps-end-string                | " "                    | String used at the end of each strings in steps of a solution.                          |
-| litex-math-inline-start               | "\\("                  | Opening syntax for math inline environment.                                             |
-| litex-math-inline-end                 | "\\)"                  | Closing syntax for math inline environment.                                             |
-| litex-math-equation-start             | "\\begin{equation}\n"  | Opening syntax for math equation environment.                                           |
-| litex-math-equation-end               | "\n\\end{equation}\n"  | Closing syntax for math equation environment.                                           |
-| litex-math-steps-equation-join-string | "= "                   | Value of `litex-steps-join-string' to be used in equation environment.                  |
-| litex-math-steps-equation-end-string  | " "                    | Value of `litex-steps-end-string' to be used in equation environment.                   |
-| litex-math-eqnarray-start             | "\\begin{eqnarray*}\n" | Opening syntax for math eqnarray environment.                                           |
-| litex-math-eqnarray-end               | "\n\\end{eqnarray*}\n" | Closing syntax for math eqnarray environment.                                           |
-| litex-math-steps-eqnarray-join-string | " &=& "                | Value of `litex-steps-join-string' to be used in eqnarray environment.                  |
-| litex-math-steps-eqnarray-end-string  | "\\\\\n"               | Value of `litex-steps-end-string' to be used in eqnarray environment.                   |
-| litex-math-align-start                | "\\begin{align*}\n"    | Opening syntax for math align environment.                                              |
-| litex-math-align-end                  | "\n\\end{align*}\n"    | Closing syntax for math align environment.                                              |
-| litex-math-steps-align-join-string    | "& = "                 | Value of `litex-steps-join-string' to be used in align environment.                     |
-| litex-math-steps-align-end-string     | "\\\\\n"               | Value of `litex-steps-end-string' to be used in align environment.                      |
-| litex-make-unicode-to-latex           | nil                    | Convert unicode to LaTeX equivalent (eg. α -> \alpha)                                   |
-| litex-make-name-to-latex-glyph        | nil                    | Convert variables with the same name as a glyph to a LaTeX glyph (eg. alpha -> \alpha). |
-| litex-use-slime-for-eval              | nil                    | Whether to use slime process for evalulation or not. You need to start slime yourself.  |
-| litex-greek-unicode-latex-alist       |                        | Alist of greek unicode symbols and their LaTeX counterparts.                            |
+| Variable Name                         | Default Value          | What it does                                                            |
+|---------------------------------------+------------------------+-------------------------------------------------------------------------|
+| litex-latex-functions                 | '(sin cos tan)         | Lisp functions that have their own latex commands.                     |
+| litex-make-hyphenated-to-subscript    | t                      | Whether to make the hyphenated variables subscript or not.             |
+| litex-latex-maybe-enclose?            | nil                    | Enclose latex converted to paran if needed.                            |
+| litex-format-float-string             | "%.3f"                 | Format string to be used by floats.                                    |
+| litex-format-float-upper-limit        | 1e4                    | Upper limit of what number is formatted as float.                      |
+| litex-format-float-lower-limit        | 1e-2                   | Lower limit of what number is formatted as float.                      |
+| litex-steps-join-string               | "= "                   | String used for joining strings in steps of a solution.                |
+| litex-steps-end-string                | " "                    | String used at the end of each strings in steps of a solution.         |
+| litex-math-inline-start               | "\\("                  | Opening syntax for math inline environment.                            |
+| litex-math-inline-end                 | "\\)"                  | Closing syntax for math inline environment.                            |
+| litex-math-equation-start             | "\\begin{equation}\n"  | Opening syntax for math equation environment.                          |
+| litex-math-equation-end               | "\n\\end{equation}\n"  | Closing syntax for math equation environment.                          |
+| litex-math-steps-equation-join-string | "= "                   | Value of `litex-steps-join-string' to be used in equation environment. |
+| litex-math-steps-equation-end-string  | " "                    | Value of `litex-steps-end-string' to be used in equation environment.  |
+| litex-math-eqnarray-start             | "\\begin{eqnarray*}\n" | Opening syntax for math eqnarray environment.                          |
+| litex-math-eqnarray-end               | "\n\\end{eqnarray*}\n" | Closing syntax for math eqnarray environment.                          |
+| litex-math-steps-eqnarray-join-string | " &=& "                | Value of `litex-steps-join-string' to be used in eqnarray environment. |
+| litex-math-steps-eqnarray-end-string  | "\\\\\n"               | Value of `litex-steps-end-string' to be used in eqnarray environment.  |
 
 
+  
 * Contributing
   Since this package is new, I'd appreciate contributions on few things:
 

--- a/README.org
+++ b/README.org
@@ -17,7 +17,35 @@ For example if you look at this image you can see how just 1 lines of lisp expre
 
 Not only can it convert lisp expressions to latex, it can also, give intermediate solution steps. Perfect for doing homeworks (as that's what I made it for) :P
 
-NOTE: elisp uses integer calculations so ~(/ 1 2)~ is evaluated to 0, be careful of such pitfalls. For now ~(/ 1.0 2)~ is evaluated as ~0.5~, so I'd recommend using floats when you need floats, and I'm working on optional integration with slime which doesn't have this problem.
+
+* Table of contents :TOC:
+- [[#litex-mode][LiTeX mode]]
+- [[#how-to-use][How to Use]]
+- [[#installation][Installation]]
+- [[#usage][Usage]]
+- [[#keybindings][Keybindings]]
+  - [[#setting-keybindings-for-individual-functions][Setting keybindings for individual functions]]
+  - [[#setting-the-whole-litex-provided-keybindings-to-a-prefix-key][Setting the whole litex provided keybindings to a prefix key]]
+  - [[#complete-setup-using-use-package][Complete setup using use-package]]
+- [[#known-problems][Known Problems:]]
+- [[#tips-and-tricks][Tips and Tricks]]
+  - [[#using-case-sensitive-symbols][Using case sensitive symbols]]
+  - [[#slime-integration][Slime integration]]
+  - [[#using-greek-letters][Using Greek letters]]
+- [[#explanation-for-functions][Explanation for functions]]
+  - [[#litex-format-region-last][litex-format-region-last]]
+  - [[#litex-format-region][litex-format-region]]
+  - [[#litex-eval-and-replace][litex-eval-and-replace]]
+  - [[#litex-eval-and-insert][litex-eval-and-insert]]
+  - [[#litex-sexp-to-latex-exp][litex-sexp-to-latex-exp]]
+  - [[#litex-sexp-solve-all-steps][litex-sexp-solve-all-steps]]
+  - [[#litex-increment-number][litex-increment-number]]
+  - [[#litex-exp-to-latex][litex-exp-to-latex]]
+  - [[#litex-exp-in-latex-math][litex-exp-in-latex-math]]
+  - [[#litex-sexp-solve-all-steps-equation][litex-sexp-solve-all-steps-equation]]
+  - [[#litex-sexp-solve-all-steps-eqnarray][litex-sexp-solve-all-steps-eqnarray]]
+- [[#customization][Customization]]
+- [[#contributing][Contributing]]
 
 * How to Use
 
@@ -32,7 +60,7 @@ NOTE: elisp uses integer calculations so ~(/ 1 2)~ is evaluated to 0, be careful
 
   Or you can clone this github repo and load it using path.
 
-  Configuration section shows how you can add the load path using ~use-package~. 
+  Configuration section shows how you can add the load path using ~use-package~.
 
 * Usage
     Using ~use-package~ you can do:
@@ -44,16 +72,18 @@ NOTE: elisp uses integer calculations so ~(/ 1 2)~ is evaluated to 0, be careful
   :hook text-mode)
 #+end_src
 
-* Keybindings
-  By default LiTeX-mode doesn't provide any keybindings, but it does have a variable containing bindings for the interactive functions that you can use. 
+Please look through the Keybindings, Functions, Variables, Known problems and the Tips and Tricks to get 100% out of this package.
 
-  
+* Keybindings
+  By default LiTeX-mode doesn't provide any keybindings, but it does have a variable containing bindings for the interactive functions that you can use.
+
+
 ** Setting keybindings for individual functions
    You can use ~local-set-key~ to bind individual functions to a key binding.
 #+begin_src emacs-lisp :tangle yes
   (local-set-key (kbd "×") 'litex-insert-or-replace-x)
 #+end_src
-   
+
 ** Setting the whole litex provided keybindings to a prefix key
 
    You can set a prefix key (~C-e~ for me here) like in this example, which makes it so you can for example use ~litex-format-region-last~ using ~C-e f~ using the following in your config. In some cases you might have to unset key ~C-e~ because it's used to goto end of line, I'm replacing that because I don't use it (as ~End~ key does the same).
@@ -61,7 +91,7 @@ NOTE: elisp uses integer calculations so ~(/ 1 2)~ is evaluated to 0, be careful
   (local-set-key (kbd "C-e") litex-key-map)
    #+end_src
 
-   
+
 Contents of litex-key-map are below.
 
   #+begin_src emacs-lisp :tangle yes
@@ -78,7 +108,7 @@ Contents of litex-key-map are below.
 (define-key litex-key-map (kbd "a") 'litex-sexp-solve-all-steps-eqnarray)
   #+end_src
 
-  
+
 ** Complete setup using use-package
    This is the complete setup using use-package, if you installed from melpa. If you installed by cloning the repo, uncomment and provide the load path.
   #+begin_src emacs-lisp :tangle yes
@@ -90,6 +120,57 @@ Contents of litex-key-map are below.
   (local-set-key (kbd "C-e") litex-key-map)
   (local-set-key (kbd "×") 'litex-insert-or-replace-x))
   #+end_src
+
+
+* Known Problems:
+   elisp uses integer calculations so ~(/ 1 2)~ is evaluated to 0, be careful of such pitfalls. For now ~(/ 1.0 2)~ is evaluated as ~0.5~, so I'd recommend using floats when you need floats.
+
+   This problem doesn't exist if you use slime integration.
+
+* Tips and Tricks
+
+** Using case sensitive symbols
+   Inside emacs the symbols are read without case sensitivity, so if you define and variable names ~ABCD~, it'll replace the variable named ~abcd~. To avoid that, specially if you have formula with both lowercase and uppercase symbols you can use this customization.
+
+   #+begin_src emacs-lisp :tangle yes
+  (setq readtable-case :preserve)
+   #+end_src
+
+   NOTE: Currently it only works for elisp, and not for slime integration, I'm searching for a solution with slime.
+
+** Slime integration
+   If you want to do the calculations in your favorite lisp dilect instead of doing it in elisp, or polluting the emacs environment with your variables, or mistakenly messing something up. You can start a slime process with ~slime~ and use that process to evaluate everything.
+
+   You Only need to set this configuration variable true:
+
+#+begin_src emacs-lisp :tangle yes
+(setq litex-use-slime-for-eval t)
+#+end_src
+
+** Using Greek letters
+   Someone who writes in LaTeX will definitely want to include greek letters, so you can use greek letters multiple ways in LiTeX.
+
+*** By double escaping the backslash
+    You can use double escape to escape the backslash so you'll get the variable correct. For example: ~(setq \\alpha 2)~ ⇒ ~\alpha = 2~
+
+*** Using Unicode:
+    You can input unicode greek letters like α,β,γ...,Σ...,Ω, and they'll be rendered fine by LaTeX. For example: ~(setq α 2)~ ⇒ ~α = 2~. Which is the default behavior.
+
+    If you want to use them to input, but still want to use LaTeX equivalent command then you can set ~litex-make-unicode-to-latex~ to true, that'll convert the unicode to LaTeX command. For example: ~(setq α 2)~ ⇒ ~{\alpha} = 2~.
+
+    #+begin_src emacs-lisp :tangle yes
+(setq litex-make-unicode-to-latex t)
+    #+end_src
+
+    As for how to type unicode directly, you can use Compose key in Linux machines, and there is also TeX input method in emacs that lets you do that. If you type ~C-u C-\ TeX <RET>~ for TeX input method then when you type ~\alpha~ emacs will convert it into unicode ~α~.
+
+*** Using conversion from their names
+    By default you can use variables names like ~alpha~ without having it any effect, for example: ~(setq alpha 2)~ ⇒ ~alpha = 2~ but if you set the variable ~litex-make-name-to-latex-glyph~ true then you can just convert normal greek character's names to LaTeX symbols.
+Like: ~(setq alpha 2)~ ⇒ ~{\alpha} = 2~
+
+    #+begin_src emacs-lisp :tangle yes
+(setq litex-make-name-to-latex-glyph t)
+    #+end_src
 
 
 * Explanation for functions
@@ -169,29 +250,36 @@ y &=& 2 + 3 + 6 x \\
 * Customization
   There are lots of variables that define how each of these functions behave.
 
-| Variable Name                         | Default Value          | What it does                                                            |
-|---------------------------------------+------------------------+-------------------------------------------------------------------------|
-| litex-latex-functions                 | '(sin cos tan)         | Lisp functions that have their own latex commands.                     |
-| litex-make-hyphenated-to-subscript    | t                      | Whether to make the hyphenated variables subscript or not.             |
-| litex-latex-maybe-enclose?            | nil                    | Enclose latex converted to paran if needed.                            |
-| litex-format-float-string             | "%.3f"                 | Format string to be used by floats.                                    |
-| litex-format-float-upper-limit        | 1e4                    | Upper limit of what number is formatted as float.                      |
-| litex-format-float-lower-limit        | 1e-2                   | Lower limit of what number is formatted as float.                      |
-| litex-steps-join-string               | "= "                   | String used for joining strings in steps of a solution.                |
-| litex-steps-end-string                | " "                    | String used at the end of each strings in steps of a solution.         |
-| litex-math-inline-start               | "\\("                  | Opening syntax for math inline environment.                            |
-| litex-math-inline-end                 | "\\)"                  | Closing syntax for math inline environment.                            |
-| litex-math-equation-start             | "\\begin{equation}\n"  | Opening syntax for math equation environment.                          |
-| litex-math-equation-end               | "\n\\end{equation}\n"  | Closing syntax for math equation environment.                          |
-| litex-math-steps-equation-join-string | "= "                   | Value of `litex-steps-join-string' to be used in equation environment. |
-| litex-math-steps-equation-end-string  | " "                    | Value of `litex-steps-end-string' to be used in equation environment.  |
-| litex-math-eqnarray-start             | "\\begin{eqnarray*}\n" | Opening syntax for math eqnarray environment.                          |
-| litex-math-eqnarray-end               | "\n\\end{eqnarray*}\n" | Closing syntax for math eqnarray environment.                          |
-| litex-math-steps-eqnarray-join-string | " &=& "                | Value of `litex-steps-join-string' to be used in eqnarray environment. |
-| litex-math-steps-eqnarray-end-string  | "\\\\\n"               | Value of `litex-steps-end-string' to be used in eqnarray environment.  |
+| Variable Name                         | Default Value          | What it does                                                                            |
+|---------------------------------------+------------------------+-----------------------------------------------------------------------------------------|
+| litex-latex-functions                 | '(sin cos tan)         | Lisp functions that have their own latex commands.                                      |
+| litex-make-hyphenated-to-subscript    | t                      | Whether to make the hyphenated variables subscript or not.                              |
+| litex-latex-maybe-enclose?            | nil                    | Enclose latex converted to paran if needed.                                             |
+| litex-format-float-string             | "%.3f"                 | Format string to be used by floats.                                                     |
+| litex-format-float-upper-limit        | 1e4                    | Upper limit of what number is formatted as float.                                       |
+| litex-format-float-lower-limit        | 1e-2                   | Lower limit of what number is formatted as float.                                       |
+| litex-steps-join-string               | "= "                   | String used for joining strings in steps of a solution.                                 |
+| litex-steps-end-string                | " "                    | String used at the end of each strings in steps of a solution.                          |
+| litex-math-inline-start               | "\\("                  | Opening syntax for math inline environment.                                             |
+| litex-math-inline-end                 | "\\)"                  | Closing syntax for math inline environment.                                             |
+| litex-math-equation-start             | "\\begin{equation}\n"  | Opening syntax for math equation environment.                                           |
+| litex-math-equation-end               | "\n\\end{equation}\n"  | Closing syntax for math equation environment.                                           |
+| litex-math-steps-equation-join-string | "= "                   | Value of `litex-steps-join-string' to be used in equation environment.                  |
+| litex-math-steps-equation-end-string  | " "                    | Value of `litex-steps-end-string' to be used in equation environment.                   |
+| litex-math-eqnarray-start             | "\\begin{eqnarray*}\n" | Opening syntax for math eqnarray environment.                                           |
+| litex-math-eqnarray-end               | "\n\\end{eqnarray*}\n" | Closing syntax for math eqnarray environment.                                           |
+| litex-math-steps-eqnarray-join-string | " &=& "                | Value of `litex-steps-join-string' to be used in eqnarray environment.                  |
+| litex-math-steps-eqnarray-end-string  | "\\\\\n"               | Value of `litex-steps-end-string' to be used in eqnarray environment.                   |
+| litex-math-align-start                | "\\begin{align*}\n"    | Opening syntax for math align environment.                                              |
+| litex-math-align-end                  | "\n\\end{align*}\n"    | Closing syntax for math align environment.                                              |
+| litex-math-steps-align-join-string    | "& = "                 | Value of `litex-steps-join-string' to be used in align environment.                     |
+| litex-math-steps-align-end-string     | "\\\\\n"               | Value of `litex-steps-end-string' to be used in align environment.                      |
+| litex-make-unicode-to-latex           | nil                    | Convert unicode to LaTeX equivalent (eg. α -> \alpha)                                   |
+| litex-make-name-to-latex-glyph        | nil                    | Convert variables with the same name as a glyph to a LaTeX glyph (eg. alpha -> \alpha). |
+| litex-use-slime-for-eval              | nil                    | Whether to use slime process for evalulation or not. You need to start slime yourself.  |
+| litex-greek-unicode-latex-alist       |                        | Alist of greek unicode symbols and their LaTeX counterparts.                            |
 
 
-  
 * Contributing
   Since this package is new, I'd appreciate contributions on few things:
 

--- a/litex-mode.el
+++ b/litex-mode.el
@@ -214,13 +214,15 @@
       var-final)))
 
 
+;; this function needs some serious thoughts
 (defun litex-latex-maybe-enclose (form)
-  "Encloses FORM in parantheis if LITEX-LATEX-MAYBE-ENCLOSE is true."
+  "Encloses FORM in parantheis if LITEX-LATEX-MAYBE-ENCLOSE? is true."
   (let* ((latex (litex-lisp2latex-all form)))
-    (if (and (consp form)
-	     (not (and (functionp (car form))
-		       (litex-latex-enclose-check-function (car form))))
-	     litex-latex-maybe-enclose?)
+    (if (and 
+	 ;; litex-latex-maybe-enclose?
+	 (consp form)
+	 (not (and (functionp (car form))
+		   (litex-latex-enclose-check-function (car form)))))
         (format "%s %s %s"
 		litex-math-brackets-start
 		latex
@@ -234,7 +236,7 @@
       nil
     (or
      (> (length args) 1)
-     (listp (car args)))))
+     (cl-some #'listp args))))
 
 
 (defun litex-latex-enclose-check-function (func)
@@ -251,7 +253,7 @@
 (defun litex-format-args-+ (args)
   "Formatting function for + operator called with ARGS."
   (let ((litex-latex-maybe-enclose? t))
-    (mapconcat #'litex-lisp2latex-all args " + ")))
+    (mapconcat #'litex-latex-maybe-enclose args " + ")))
 
 
 (defun litex-format-args-- (args)
@@ -259,9 +261,9 @@
   (let ((arg1 (car args))
 	(arg-rest (cdr args)))
     (if arg-rest
-        (format "%s - %s" (litex-lisp2latex-all arg1)
-                (mapconcat #'litex-lisp2latex-all arg-rest " - "))
-      (format "-%s" (litex-lisp2latex-all arg1)))))
+        (format "%s - %s" (litex-latex-maybe-enclose arg1)
+                (mapconcat #'litex-latex-maybe-enclose arg-rest " - "))
+      (format "-%s" (litex-latex-maybe-enclose arg1)))))
 
 
 (defun litex-format-args-* (args)
@@ -271,6 +273,7 @@
 	     (let* ((litex-latex-maybe-enclose?
 		     (or (> (length args) 1)
 			 (litex-latex-enclose-check-args me))))
+
 	       (princ (format "%s"
 			      (litex-latex-maybe-enclose me)))
 	       (if (and next
@@ -288,19 +291,19 @@
 	(litex-latex-maybe-enclose? nil))
     (if arg-rest
 	(format "\\frac{%s}{%s}"
-		(litex-lisp2latex-all arg1)
-		(litex-lisp2latex-all (cons '* arg-rest)))
-      (format "\\frac1{%s}" (litex-lisp2latex-all arg1)))))
+		(litex-latex-maybe-enclose arg1)
+		(litex-latex-maybe-enclose (cons '* arg-rest)))
+      (format "\\frac1{%s}" (litex-latex-maybe-enclose arg1)))))
 
 
 (defun litex-format-args-1+ (args)
   "Formatting function for 1+ called with ARGS operator."
-  (concat (litex-lisp2latex-all (car args)) " + 1"))
+  (concat (litex-latex-maybe-enclose (car args)) " + 1"))
 
 
 (defun litex-format-args-1- (args)
   "Formatting function for 1- called with ARGS operator."
-  (concat (litex-lisp2latex-all (car args)) " - 1"))
+  (concat (litex-latex-maybe-enclose (car args)) " - 1"))
 
 
 (defun litex-format-args-expt (args)
@@ -310,17 +313,17 @@
     (if (listp base)
 	(format "%s %s %s^{%s}"
 		litex-math-brackets-start
-		(litex-lisp2latex-all base)
+		(litex-latex-maybe-enclose base)
 		litex-math-brackets-end
-		(litex-lisp2latex-all power))
+		(litex-latex-maybe-enclose power))
       (format "%s^{%s}"
-	      (litex-lisp2latex-all base)
-	      (litex-lisp2latex-all power)))))
+	      (litex-latex-maybe-enclose base)
+	      (litex-latex-maybe-enclose power)))))
 
 
 (defun litex-format-args-sqrt (args)
   "Formatting function for sqrt function called with ARGS."
-  (format "\\sqrt{%s}" (litex-lisp2latex-all (car args))))
+  (format "\\sqrt{%s}" (litex-latex-maybe-enclose (car args))))
 
 
 (defun litex-format-args-setq (args)
@@ -328,8 +331,8 @@
   (with-output-to-string
     (cl-loop for (a b . rest) on args by #'cddr do
 	     (princ (format "%s = %s"
-			    (litex-lisp2latex-all a)
-			    (litex-lisp2latex-all b)))
+			    (litex-latex-maybe-enclose a)
+			    (litex-latex-maybe-enclose b)))
 	     (when rest (princ "; ")))))
 
 
@@ -345,7 +348,7 @@
     (format "\\mathrm{%s}(%s):%s"
 	    (litex-format-variable func-name)
 	    (mapconcat #'prin1-to-string fargs ",")
-	    (litex-lisp2latex-all expr))))
+	    (litex-latex-maybe-enclose expr))))
 
 
 (defun litex-format-args-default (func args)
@@ -370,7 +373,7 @@ format."
 						litex-math-brackets-end)
 				      " %s"))))
 	(format format-string func
-		(mapconcat #'litex-lisp2latex-all args ","))))))
+		(mapconcat #'litex-latex-maybe-enclose args ","))))))
 
 
 (defun litex-lisp2latex-all (form)

--- a/litex-mode.el
+++ b/litex-mode.el
@@ -35,6 +35,7 @@
 ;;; Code:
 (eval-when-compile (require 'pcase))
 (require 'cl-lib)
+(require 'ob-lisp)
 
 ;; list from:
 ;; https://www.overleaf.com/learn/latex/Operators#Reference_guide
@@ -44,6 +45,10 @@
 	arctan cot det hom lim log sec tan arg coth dim liminf max
 	sin tanh)
   "Lisp functions that have their own latex commands.")
+(defvar litex-make-unicode-to-latex nil
+  "Whether to convert unicode to LaTeX equivalent (eg. α -> \alpha). These work better in math mode.")
+(defvar litex-make-name-to-latex-glyph nil
+  "Whether to convert variables with the same name as a glyph to a LaTeX glyph (eg. alpha -> \alpha).")
 (defvar litex-make-hyphenated-to-subscript t
   "Whether to make the hyphenated variables subscript or not.")
 (defvar litex-latex-maybe-enclose? nil
@@ -99,9 +104,63 @@
 (defvar litex-math-steps-align-end-string "\\\\\n"
   "Value of `litex-steps-end-string' to be used in align environment.")
 
+(defvar litex-use-slime-for-eval nil
+  "Whether to use slime process for evalulation or not. You need to start slime yourself.")
+
+
+(defvar litex-greek-unicode-latex-alist
+  '(("α" . "alpha")
+    ("β" . "beta")
+    ("γ" . "gamma")
+    ("δ" . "delta")
+    ("ε" . "epsilon")
+    ("ϵ" . "varepsilon")
+    ("ζ" . "zeta")
+    ("η" . "eta")
+    ("θ" . "theta")
+    ("ϑ" . "vartheta")
+    ("ι" . "iota")
+    ("κ" . "kappa")
+    ("λ" . "lambda")
+    ("μ" . "mu")
+    ("ν" . "nu")
+    ("ξ" . "xi")
+    ("π" . "pi")
+    ("ρ" . "rho")
+    ("ϱ" . "varrho")
+    ("σ" . "sigma")
+    ("τ" . "tau")
+    ("υ" . "upsilon")
+    ("φ" . "phi")
+    ("φ" . "varphi")
+    ("χ" . "chi")
+    ("ψ" . "psi")
+    ("ω" . "omega")
+    
+    ("Γ" . "Gamma")
+    ("Δ" . "Delta")
+    ("Ζ" . "Zeta")
+    ("Θ" . "Theta")
+    ("Λ" . "Lambda")
+    ("Ξ" . "Xi")
+    ("Π" . "Pi")
+    ("Ρ" . "Rho")
+    ("Σ" . "Sigma")
+    ("Υ" . "Upsilon")
+    ("Φ" . "Phi")
+    ("Ψ" . "Psi")
+    ("Ω" . "Omega"))
+  "Alist of greek unicode symbols and their LaTeX counterparts.")
 
 
 
+(defun litex-eval (expr)
+  "Eval funcion used by LiTeX, evals the EXPR in elisp or slime."
+  (if litex-use-slime-for-eval
+      (org-babel-execute:lisp (prin1-to-string expr) '())
+    (eval expr)))
+
+;; Formatting functions
 (defun litex-format-float (val)
   "Function that defines how float VAL is formatted in lisp2latex."
   (if (or (< val litex-format-float-lower-limit)
@@ -126,15 +185,33 @@
     expr))
 
 
+(defun litex-format-greek-characters (string)
+  "Format STRING to Greek LaTeX notation if it has greek unicode or character name."
+  (let ((var-str string)
+	(var-assoc nil))
+    (when litex-make-name-to-latex-glyph
+      (when (rassoc var-str litex-greek-unicode-latex-alist)
+	(setq var-str (concat "{\\" var-str "}"))))
+    (when litex-make-unicode-to-latex
+      (setq var-assoc (cdr (assoc var-str litex-greek-unicode-latex-alist)))
+      (when var-assoc
+	(setq var-str
+	      (concat "{\\" var-assoc "}"))))
+    var-str))
+
+
 (defun litex-format-variable (var)
   "Format variable VAR for LaTeX."
-  (let ((var-str (prin1-to-string var)))
-    (if litex-make-hyphenated-to-subscript
-	(while (string-match "\\([^-]+\\)[-]\\(.*\\)" var-str)
-	  (setq var-str (format "%s_{%s}"
-				(match-string 1 var-str)
-				(match-string 2 var-str)))))
-    var-str))
+  (let ((var-strs (mapcar
+		   (lambda (s) (mapconcat #'litex-format-greek-characters
+				     (split-string s "/") ""))
+		   (split-string (prin1-to-string var t) "-"))))
+
+    (let ((var-final (car var-strs)))
+      (if (> (length var-strs) 1)
+	  (cl-loop for (cvar . rest) on (cl-rest var-strs) do
+		   (setq var-final (format "%s_{%s}" var-final cvar))))
+      var-final)))
 
 
 (defun litex-latex-maybe-enclose (form)
@@ -306,7 +383,7 @@ format."
     ;; simple variables
     (_
      (cond ((floatp form) (litex-format-float form))
-	   ((symbolp form) (litex-format-variable form))
+	   ((or (symbolp form) (stringp form)) (litex-format-variable form))
            (t (prin1-to-string form))))))
 
 
@@ -324,23 +401,23 @@ format."
 (defun litex-substitute-values (expression)
   "Gives a string from EXPRESSION substituting the values."
   (condition-case nil
-      (if (functionp expression)
-	  (format "%s" expression)
-	(if (symbolp expression)
-	    (format "%s" (eval expression))
-	  (if (consp expression)
-	      (format "(%s)"
-		      (mapconcat #'litex-substitute-values expression " "))
-	    (prin1-to-string expression))))
-    ;; this will catch error for undefined variables.
-    (void-variable (prin1-to-string expression))))
+   (if (functionp expression)
+      (format "%s" expression)
+    (if (symbolp expression)
+	(format "%s" (litex-eval expression))
+      (if (consp expression)
+	  (format "(%s)"
+		  (mapconcat #'litex-substitute-values expression " "))
+	(prin1-to-string expression))))
+   ;; this will catch error for undefined variables.
+   (void-variable (prin1-to-string expression))))
 
 
 (defun litex-solve-single-step (form)
   "Solves a single step of calculation in FORM."
   (cond ((listp form)
          (if (cl-every #'numberp (cl-rest form))
-             (eval form)
+             (litex-eval form)
            (cons (cl-first form)
 		 (mapcar #'litex-solve-single-step (cl-rest form)))))
 	((functionp form)
@@ -396,7 +473,7 @@ format."
   (interactive)
   (backward-kill-sexp)
   (condition-case nil
-      (prin1 (eval (read (current-kill 0)))
+      (prin1 (litex-eval (read (current-kill 0)))
              (current-buffer))
     (error (message "Invalid expression")
            (insert (current-kill 0)))))
@@ -410,7 +487,7 @@ format."
       (insert (current-kill 0)
 	      litex-steps-join-string
 	      (format "%s"
-		      (eval (read (current-kill 0)))))
+		      (litex-eval (read (current-kill 0)))))
     (error (message "Invalid expression"))))
 
 
@@ -506,9 +583,9 @@ Argument END end position of region."
                  (let ((bnd (bounds-of-thing-at-point 'sexp)))
 		   (list (cl-first bnd) (cl-rest bnd)))))
   (let ((text (buffer-substring-no-properties beg end)))
-    ;; maybe I should make it eval if given expression
+    ;; maybe I should make it litex-eval if given expression
     (if (string-match-p "%[0-9.]*[dfex]" litex-format-float-string)
-	(setq text (eval (read text))))
+	(setq text (litex-eval (read text))))
     (kill-region beg end)
     (insert (format litex-format-float-string text))))
 

--- a/litex-mode.texi
+++ b/litex-mode.texi
@@ -21,14 +21,35 @@
 @menu
 * Li@TeX{} mode::
 * How to Use::
+* Installation::
+* Usage::
 * Keybindings::
+* Known Problems:: Known Problems. 
+* Tips and Tricks::
 * Explanation for functions::
 * Customization::
-* Configuration::
 * Contributing::
 
 @detailmenu
 --- The Detailed Node Listing ---
+
+Keybindings
+
+* Setting keybindings for individual functions::
+* Setting the whole litex provided keybindings to a prefix key::
+* Complete setup using use-package::
+
+Tips and Tricks
+
+* Using case sensitive symbols::
+* Slime integration::
+* Using Greek letters::
+
+Using Greek letters
+
+* By double escaping the backslash::
+* Using Unicode:: Using Unicode. 
+* Using conversion from their names::
 
 Explanation for functions
 
@@ -62,56 +83,9 @@ The beginning of this mode, and previous codes are here:
 @uref{https://gist.github.com/bpanthi977/4b8ece0eeff3bc05bb82275a23cbb56d, Bibek's gist}
 @item
 @uref{https://github.com/Atreyagaurav/emacs-modules, My previous calculation template mode and first few versions of Li@TeX{}}
-
-Suppose we have this in a text file, we have all the variables and the formula as lisp expressions.
 @end itemize
-@example
-   Net radiation, (setq R_n 185) W/m²
-   Temperature, (setq T 28.5) °C
-   Relative Humidity, (setq Rh .55)
-   Air velocity at 2m height, (setq u_2 2.7) m/s
-   Atmospheric pressure, (setq p 101.3e3) Pa
-   Roughness height, (setq Z_0 0.03) cm
-   (setq Z_2 200) cm
 
-   Energy balance method:
-   (setq E_r (/ (- R_n H_s G) l_v ρ_w))
-
-   Where,
-   (setq l_v (- 2500 (* 2.36 T))) kJ/kg
-   (setq l_v (* l_v 1e3)) J/kg
-   From table 2.5.2
-   (setq ρ_w 996.4) kg/m³
-
-   Assume, (setq H_s 0 G 0)
-   (setq E_r (/ (- R_n H_s G) l_v ρ_w))
-@end example
-
-After evaluating all expressions, we can get the values, while we can also convert them to latex format like this:
-@example
-   Net radiation, R_n = 185 W/m²
-   Temperature, T = 28.5 °C
-   Relative Humidity, Rh = 0.55
-   Air velocity at 2m height, u_2 = 2.7 m/s
-   Atmospheric pressure, p = 1.01 \times 10^@{5@} Pa
-   Roughness height, Z_0 = 0.3 cm
-   Z_2 = 200 cm
-
-   Energy balance method:
-   E_r = \frac@{R_n - H_s - G@}@{l_v ρ_w @}
-
-   Where,
-   l_v = 2500 - 2.360 T  = 2500 - 2.360 \times 28.500  = 2500 - 67.260 = 2432.74 kJ/kg
-   l_v = l_v \times 1000  = 2432740.0 J/kg
-   From table 2.5.2
-   ρ_w = 996.400 kg/m³
-
-   Assume, H_s = 0; G = 0
-   E_r = \frac@{R_n - H_s - G@}@{l_v ρ_w @} = \frac@{185 - 0 - 0@}@{2432.740 \times 996.400 @} = \frac@{185@}@{2432.740 \times 996.400 @} = 7.63 \times 10^@{-05@}
-@end example
-
-So not only can it convert lisp expressions to latex, it can also, give intermediate solution steps. Perfect for doing homeworks (as that's what I made it for) :P
-
+Not only can it convert lisp expressions to latex, it can also, give intermediate solution steps. Perfect for doing homeworks (as that's what I made it for) :P
 
 @node How to Use
 @chapter How to Use
@@ -122,8 +96,58 @@ For Text descriptions refer sections below for details on what each function doe
 
 You can also access it all from texinfo file provided with the package.
 
+@node Installation
+@chapter Installation
+
+You can install it through melpa with @code{M-x package-install litex-mode <ret>}.
+
+Or you can clone this github repo and load it using path.
+
+Configuration section shows how you can add the load path using @code{use-package}.
+
+@node Usage
+@chapter Usage
+
+Using @code{use-package} you can do:
+
+@lisp
+(use-package litex-mode
+  ;; :load-path "/path/to/litex-mode/"
+  :commands litex-mode
+  :hook text-mode)
+@end lisp
+
+Please look through the Keybindings, Functions, Variables, Known problems and the Tips and Tricks to get 100% out of this package.
+
 @node Keybindings
 @chapter Keybindings
+
+By default Li@TeX{}-mode doesn't provide any keybindings, but it does have a variable containing bindings for the interactive functions that you can use.
+
+@menu
+* Setting keybindings for individual functions::
+* Setting the whole litex provided keybindings to a prefix key::
+* Complete setup using use-package::
+@end menu
+
+@node Setting keybindings for individual functions
+@section Setting keybindings for individual functions
+
+You can use @code{local-set-key} to bind individual functions to a key binding.
+@lisp
+  (local-set-key (kbd "×") 'litex-insert-or-replace-x)
+@end lisp
+
+@node Setting the whole litex provided keybindings to a prefix key
+@section Setting the whole litex provided keybindings to a prefix key
+
+You can set a prefix key (@code{C-e} for me here) like in this example, which makes it so you can for example use @code{litex-format-region-last} using @code{C-e f} using the following in your config. In some cases you might have to unset key @code{C-e} because it's used to goto end of line, I'm replacing that because I don't use it (as @code{End} key does the same).
+@lisp
+  (local-set-key (kbd "C-e") litex-key-map)
+@end lisp
+
+
+Contents of litex-key-map are below.
 
 @lisp
 (define-key litex-key-map (kbd "F") 'litex-format-region)
@@ -137,6 +161,97 @@ You can also access it all from texinfo file provided with the package.
 (define-key litex-key-map (kbd "m") 'litex-exp-in-latex-math)
 (define-key litex-key-map (kbd "A") 'litex-sexp-solve-all-steps-equation)
 (define-key litex-key-map (kbd "a") 'litex-sexp-solve-all-steps-eqnarray)
+@end lisp
+
+@node Complete setup using use-package
+@section Complete setup using use-package
+
+This is the complete setup using use-package, if you installed from melpa. If you installed by cloning the repo, uncomment and provide the load path.
+@lisp
+(use-package litex-mode
+  ;; :load-path "/path/to/litex-mode/"
+  :commands litex-mode
+  :hook text-mode
+  :config
+  (local-set-key (kbd "C-e") litex-key-map)
+  (local-set-key (kbd "×") 'litex-insert-or-replace-x))
+@end lisp
+
+@node Known Problems
+@chapter Known Problems:
+
+elisp uses integer calculations so @code{(/ 1 2)} is evaluated to 0, be careful of such pitfalls. For now @code{(/ 1.0 2)} is evaluated as @code{0.5}, so I'd recommend using floats when you need floats.
+
+This problem doesn't exist if you use slime integration.
+
+@node Tips and Tricks
+@chapter Tips and Tricks
+
+@menu
+* Using case sensitive symbols::
+* Slime integration::
+* Using Greek letters::
+@end menu
+
+@node Using case sensitive symbols
+@section Using case sensitive symbols
+
+Inside emacs the symbols are read without case sensitivity, so if you define and variable names @code{ABCD}, it'll replace the variable named @code{abcd}. To avoid that, specially if you have formula with both lowercase and uppercase symbols you can use this customization.
+
+@lisp
+  (setq readtable-case :preserve)
+@end lisp
+
+NOTE: Currently it only works for elisp, and not for slime integration, I'm searching for a solution with slime.
+
+@node Slime integration
+@section Slime integration
+
+If you want to do the calculations in your favorite lisp dilect instead of doing it in elisp, or polluting the emacs environment with your variables, or mistakenly messing something up. You can start a slime process with @code{slime} and use that process to evaluate everything.
+
+You Only need to set this configuration variable true:
+
+@lisp
+(setq litex-use-slime-for-eval t)
+@end lisp
+
+@node Using Greek letters
+@section Using Greek letters
+
+Someone who writes in @LaTeX{} will definitely want to include greek letters, so you can use greek letters multiple ways in Li@TeX{}.
+
+@menu
+* By double escaping the backslash::
+* Using Unicode:: Using Unicode. 
+* Using conversion from their names::
+@end menu
+
+@node By double escaping the backslash
+@subsection By double escaping the backslash
+
+You can use double escape to escape the backslash so you'll get the variable correct. For example: @code{(setq \\alpha 2)} ⇒ @code{\alpha = 2}
+
+@node Using Unicode
+@subsection Using Unicode:
+
+You can input unicode greek letters like α,β,γ@dots{},Σ@dots{},Ω, and they'll be rendered fine by @LaTeX{}. For example: @code{(setq α 2)} ⇒ @code{α = 2}. Which is the default behavior.
+
+If you want to use them to input, but still want to use @LaTeX{} equivalent command then you can set @code{litex-make-unicode-to-latex} to true, that'll convert the unicode to @LaTeX{} command. For example: @code{(setq α 2)} ⇒ @code{@{\alpha@} = 2}.
+
+@lisp
+(setq litex-make-unicode-to-latex t)
+@end lisp
+
+As for how to type unicode directly, you can use Compose key in Linux machines, and there is also @TeX{} input method in emacs that lets you do that. If you type @code{C-u C-\ TeX <RET>} for @TeX{} input method then when you type @code{\alpha} emacs will convert it into unicode @code{α}.
+
+@node Using conversion from their names
+@subsection Using conversion from their names
+
+By default you can use variables names like @code{alpha} without having it any effect, for example: @code{(setq alpha 2)} ⇒ @code{alpha = 2} but if you set the variable @code{litex-make-name-to-latex-glyph} true then you can just convert normal greek character's names to @LaTeX{} symbols.
+Like: @code{(setq alpha 2)} ⇒ @code{@{\alpha@} = 2}
+
+@lisp
+(setq litex-make-name-to-latex-glyph t)
 @end lisp
 
 @node Explanation for functions
@@ -253,7 +368,7 @@ y &=& 2 + 3 + 6 x \\
 
 There are lots of variables that define how each of these functions behave.
 
-@multitable {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+@multitable {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
 @headitem Variable Name
 @tab Default Value
 @tab What it does
@@ -311,23 +426,31 @@ There are lots of variables that define how each of these functions behave.
 @item litex-math-steps-eqnarray-end-string
 @tab "\\\\"
 @tab Value of `litex-steps-end-string' to be used in eqnarray environment.
+@item litex-math-align-start
+@tab "\"
+@tab Opening syntax for math align environment.
+@item litex-math-align-end
+@tab "\"
+@tab Closing syntax for math align environment.
+@item litex-math-steps-align-join-string
+@tab "& = "
+@tab Value of `litex-steps-join-string' to be used in align environment.
+@item litex-math-steps-align-end-string
+@tab "\\\\"
+@tab Value of `litex-steps-end-string' to be used in align environment.
+@item litex-make-unicode-to-latex
+@tab nil
+@tab Convert unicode to @LaTeX{} equivalent (eg. α -> α)
+@item litex-make-name-to-latex-glyph
+@tab nil
+@tab Convert variables with the same name as a glyph to a @LaTeX{} glyph (eg. alpha -> α).
+@item litex-use-slime-for-eval
+@tab nil
+@tab Whether to use slime process for evalulation or not. You need to start slime yourself.
+@item litex-greek-unicode-latex-alist
+@tab 
+@tab Alist of greek unicode symbols and their @LaTeX{} counterparts.
 @end multitable
-
-@node Configuration
-@chapter Configuration
-
-Clone the repo into your machine and add the path to @code{load-path}, or just load the individual module you want to add.
-
-Sample configuration using @code{use-package} I use is as follows:
-
-@lisp
-(use-package litex-mode
-  :load-path "~/.emacs.d/myfunc/litex-mode/"
-  :commands litex-mode
-  :hook text-mode
-  :config (local-set-key (kbd "C-e") litex-key-map)
-  )
-@end lisp
 
 @node Contributing
 @chapter Contributing
@@ -335,6 +458,8 @@ Sample configuration using @code{use-package} I use is as follows:
 Since this package is new, I'd appreciate contributions on few things:
 
 @itemize
+@item
+Finding bugs and reporting them in github issues.
 @item
 There are many tests to be written for the functions.
 @item

--- a/litex-mode.texi
+++ b/litex-mode.texi
@@ -21,35 +21,14 @@
 @menu
 * Li@TeX{} mode::
 * How to Use::
-* Installation::
-* Usage::
 * Keybindings::
-* Known Problems:: Known Problems. 
-* Tips and Tricks::
 * Explanation for functions::
 * Customization::
+* Configuration::
 * Contributing::
 
 @detailmenu
 --- The Detailed Node Listing ---
-
-Keybindings
-
-* Setting keybindings for individual functions::
-* Setting the whole litex provided keybindings to a prefix key::
-* Complete setup using use-package::
-
-Tips and Tricks
-
-* Using case sensitive symbols::
-* Slime integration::
-* Using Greek letters::
-
-Using Greek letters
-
-* By double escaping the backslash::
-* Using Unicode:: Using Unicode. 
-* Using conversion from their names::
 
 Explanation for functions
 
@@ -83,9 +62,56 @@ The beginning of this mode, and previous codes are here:
 @uref{https://gist.github.com/bpanthi977/4b8ece0eeff3bc05bb82275a23cbb56d, Bibek's gist}
 @item
 @uref{https://github.com/Atreyagaurav/emacs-modules, My previous calculation template mode and first few versions of Li@TeX{}}
-@end itemize
 
-Not only can it convert lisp expressions to latex, it can also, give intermediate solution steps. Perfect for doing homeworks (as that's what I made it for) :P
+Suppose we have this in a text file, we have all the variables and the formula as lisp expressions.
+@end itemize
+@example
+   Net radiation, (setq R_n 185) W/m²
+   Temperature, (setq T 28.5) °C
+   Relative Humidity, (setq Rh .55)
+   Air velocity at 2m height, (setq u_2 2.7) m/s
+   Atmospheric pressure, (setq p 101.3e3) Pa
+   Roughness height, (setq Z_0 0.03) cm
+   (setq Z_2 200) cm
+
+   Energy balance method:
+   (setq E_r (/ (- R_n H_s G) l_v ρ_w))
+
+   Where,
+   (setq l_v (- 2500 (* 2.36 T))) kJ/kg
+   (setq l_v (* l_v 1e3)) J/kg
+   From table 2.5.2
+   (setq ρ_w 996.4) kg/m³
+
+   Assume, (setq H_s 0 G 0)
+   (setq E_r (/ (- R_n H_s G) l_v ρ_w))
+@end example
+
+After evaluating all expressions, we can get the values, while we can also convert them to latex format like this:
+@example
+   Net radiation, R_n = 185 W/m²
+   Temperature, T = 28.5 °C
+   Relative Humidity, Rh = 0.55
+   Air velocity at 2m height, u_2 = 2.7 m/s
+   Atmospheric pressure, p = 1.01 \times 10^@{5@} Pa
+   Roughness height, Z_0 = 0.3 cm
+   Z_2 = 200 cm
+
+   Energy balance method:
+   E_r = \frac@{R_n - H_s - G@}@{l_v ρ_w @}
+
+   Where,
+   l_v = 2500 - 2.360 T  = 2500 - 2.360 \times 28.500  = 2500 - 67.260 = 2432.74 kJ/kg
+   l_v = l_v \times 1000  = 2432740.0 J/kg
+   From table 2.5.2
+   ρ_w = 996.400 kg/m³
+
+   Assume, H_s = 0; G = 0
+   E_r = \frac@{R_n - H_s - G@}@{l_v ρ_w @} = \frac@{185 - 0 - 0@}@{2432.740 \times 996.400 @} = \frac@{185@}@{2432.740 \times 996.400 @} = 7.63 \times 10^@{-05@}
+@end example
+
+So not only can it convert lisp expressions to latex, it can also, give intermediate solution steps. Perfect for doing homeworks (as that's what I made it for) :P
+
 
 @node How to Use
 @chapter How to Use
@@ -96,58 +122,8 @@ For Text descriptions refer sections below for details on what each function doe
 
 You can also access it all from texinfo file provided with the package.
 
-@node Installation
-@chapter Installation
-
-You can install it through melpa with @code{M-x package-install litex-mode <ret>}.
-
-Or you can clone this github repo and load it using path.
-
-Configuration section shows how you can add the load path using @code{use-package}.
-
-@node Usage
-@chapter Usage
-
-Using @code{use-package} you can do:
-
-@lisp
-(use-package litex-mode
-  ;; :load-path "/path/to/litex-mode/"
-  :commands litex-mode
-  :hook text-mode)
-@end lisp
-
-Please look through the Keybindings, Functions, Variables, Known problems and the Tips and Tricks to get 100% out of this package.
-
 @node Keybindings
 @chapter Keybindings
-
-By default Li@TeX{}-mode doesn't provide any keybindings, but it does have a variable containing bindings for the interactive functions that you can use.
-
-@menu
-* Setting keybindings for individual functions::
-* Setting the whole litex provided keybindings to a prefix key::
-* Complete setup using use-package::
-@end menu
-
-@node Setting keybindings for individual functions
-@section Setting keybindings for individual functions
-
-You can use @code{local-set-key} to bind individual functions to a key binding.
-@lisp
-  (local-set-key (kbd "×") 'litex-insert-or-replace-x)
-@end lisp
-
-@node Setting the whole litex provided keybindings to a prefix key
-@section Setting the whole litex provided keybindings to a prefix key
-
-You can set a prefix key (@code{C-e} for me here) like in this example, which makes it so you can for example use @code{litex-format-region-last} using @code{C-e f} using the following in your config. In some cases you might have to unset key @code{C-e} because it's used to goto end of line, I'm replacing that because I don't use it (as @code{End} key does the same).
-@lisp
-  (local-set-key (kbd "C-e") litex-key-map)
-@end lisp
-
-
-Contents of litex-key-map are below.
 
 @lisp
 (define-key litex-key-map (kbd "F") 'litex-format-region)
@@ -161,97 +137,6 @@ Contents of litex-key-map are below.
 (define-key litex-key-map (kbd "m") 'litex-exp-in-latex-math)
 (define-key litex-key-map (kbd "A") 'litex-sexp-solve-all-steps-equation)
 (define-key litex-key-map (kbd "a") 'litex-sexp-solve-all-steps-eqnarray)
-@end lisp
-
-@node Complete setup using use-package
-@section Complete setup using use-package
-
-This is the complete setup using use-package, if you installed from melpa. If you installed by cloning the repo, uncomment and provide the load path.
-@lisp
-(use-package litex-mode
-  ;; :load-path "/path/to/litex-mode/"
-  :commands litex-mode
-  :hook text-mode
-  :config
-  (local-set-key (kbd "C-e") litex-key-map)
-  (local-set-key (kbd "×") 'litex-insert-or-replace-x))
-@end lisp
-
-@node Known Problems
-@chapter Known Problems:
-
-elisp uses integer calculations so @code{(/ 1 2)} is evaluated to 0, be careful of such pitfalls. For now @code{(/ 1.0 2)} is evaluated as @code{0.5}, so I'd recommend using floats when you need floats.
-
-This problem doesn't exist if you use slime integration.
-
-@node Tips and Tricks
-@chapter Tips and Tricks
-
-@menu
-* Using case sensitive symbols::
-* Slime integration::
-* Using Greek letters::
-@end menu
-
-@node Using case sensitive symbols
-@section Using case sensitive symbols
-
-Inside emacs the symbols are read without case sensitivity, so if you define and variable names @code{ABCD}, it'll replace the variable named @code{abcd}. To avoid that, specially if you have formula with both lowercase and uppercase symbols you can use this customization.
-
-@lisp
-  (setq readtable-case :preserve)
-@end lisp
-
-NOTE: Currently it only works for elisp, and not for slime integration, I'm searching for a solution with slime.
-
-@node Slime integration
-@section Slime integration
-
-If you want to do the calculations in your favorite lisp dilect instead of doing it in elisp, or polluting the emacs environment with your variables, or mistakenly messing something up. You can start a slime process with @code{slime} and use that process to evaluate everything.
-
-You Only need to set this configuration variable true:
-
-@lisp
-(setq litex-use-slime-for-eval t)
-@end lisp
-
-@node Using Greek letters
-@section Using Greek letters
-
-Someone who writes in @LaTeX{} will definitely want to include greek letters, so you can use greek letters multiple ways in Li@TeX{}.
-
-@menu
-* By double escaping the backslash::
-* Using Unicode:: Using Unicode. 
-* Using conversion from their names::
-@end menu
-
-@node By double escaping the backslash
-@subsection By double escaping the backslash
-
-You can use double escape to escape the backslash so you'll get the variable correct. For example: @code{(setq \\alpha 2)} ⇒ @code{\alpha = 2}
-
-@node Using Unicode
-@subsection Using Unicode:
-
-You can input unicode greek letters like α,β,γ@dots{},Σ@dots{},Ω, and they'll be rendered fine by @LaTeX{}. For example: @code{(setq α 2)} ⇒ @code{α = 2}. Which is the default behavior.
-
-If you want to use them to input, but still want to use @LaTeX{} equivalent command then you can set @code{litex-make-unicode-to-latex} to true, that'll convert the unicode to @LaTeX{} command. For example: @code{(setq α 2)} ⇒ @code{@{\alpha@} = 2}.
-
-@lisp
-(setq litex-make-unicode-to-latex t)
-@end lisp
-
-As for how to type unicode directly, you can use Compose key in Linux machines, and there is also @TeX{} input method in emacs that lets you do that. If you type @code{C-u C-\ TeX <RET>} for @TeX{} input method then when you type @code{\alpha} emacs will convert it into unicode @code{α}.
-
-@node Using conversion from their names
-@subsection Using conversion from their names
-
-By default you can use variables names like @code{alpha} without having it any effect, for example: @code{(setq alpha 2)} ⇒ @code{alpha = 2} but if you set the variable @code{litex-make-name-to-latex-glyph} true then you can just convert normal greek character's names to @LaTeX{} symbols.
-Like: @code{(setq alpha 2)} ⇒ @code{@{\alpha@} = 2}
-
-@lisp
-(setq litex-make-name-to-latex-glyph t)
 @end lisp
 
 @node Explanation for functions
@@ -368,7 +253,7 @@ y &=& 2 + 3 + 6 x \\
 
 There are lots of variables that define how each of these functions behave.
 
-@multitable {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+@multitable {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
 @headitem Variable Name
 @tab Default Value
 @tab What it does
@@ -426,31 +311,23 @@ There are lots of variables that define how each of these functions behave.
 @item litex-math-steps-eqnarray-end-string
 @tab "\\\\"
 @tab Value of `litex-steps-end-string' to be used in eqnarray environment.
-@item litex-math-align-start
-@tab "\"
-@tab Opening syntax for math align environment.
-@item litex-math-align-end
-@tab "\"
-@tab Closing syntax for math align environment.
-@item litex-math-steps-align-join-string
-@tab "& = "
-@tab Value of `litex-steps-join-string' to be used in align environment.
-@item litex-math-steps-align-end-string
-@tab "\\\\"
-@tab Value of `litex-steps-end-string' to be used in align environment.
-@item litex-make-unicode-to-latex
-@tab nil
-@tab Convert unicode to @LaTeX{} equivalent (eg. α -> α)
-@item litex-make-name-to-latex-glyph
-@tab nil
-@tab Convert variables with the same name as a glyph to a @LaTeX{} glyph (eg. alpha -> α).
-@item litex-use-slime-for-eval
-@tab nil
-@tab Whether to use slime process for evalulation or not. You need to start slime yourself.
-@item litex-greek-unicode-latex-alist
-@tab 
-@tab Alist of greek unicode symbols and their @LaTeX{} counterparts.
 @end multitable
+
+@node Configuration
+@chapter Configuration
+
+Clone the repo into your machine and add the path to @code{load-path}, or just load the individual module you want to add.
+
+Sample configuration using @code{use-package} I use is as follows:
+
+@lisp
+(use-package litex-mode
+  :load-path "~/.emacs.d/myfunc/litex-mode/"
+  :commands litex-mode
+  :hook text-mode
+  :config (local-set-key (kbd "C-e") litex-key-map)
+  )
+@end lisp
 
 @node Contributing
 @chapter Contributing
@@ -458,8 +335,6 @@ There are lots of variables that define how each of these functions behave.
 Since this package is new, I'd appreciate contributions on few things:
 
 @itemize
-@item
-Finding bugs and reporting them in github issues.
 @item
 There are many tests to be written for the functions.
 @item

--- a/tests/litex-mode-tests.el
+++ b/tests/litex-mode-tests.el
@@ -121,8 +121,13 @@
   ;; this one is failing
   (should (string= (litex-lisp2latex-all
 		    '(setq x (- t 6 (* 5 60 (/ x 2)))))
-		   "x = t - 6 - 5 \\times 60\\left( \\frac{x}{2} \\right)"))
+		   "x = t - 6 - 5 \\times 60\\frac{x}{2}"))
   (should (string= (litex-lisp2latex-all
 		    '(fun x 2 (/ 5 (+ 6 7) x)))
 		   "\\mathrm{fun}(x,2,\\frac{5}{\\left( 6 + 7 \\right)x})"))
   )
+
+(litex-format-args-* '((+ 2 3) 1))
+
+(setq litex-latex-maybe-enclose? t)
+(litex-latex-enclose-check-function '+)

--- a/tests/litex-mode-tests.el
+++ b/tests/litex-mode-tests.el
@@ -27,6 +27,25 @@
     (should (string= (litex-format-float 2.1236e-6)
 		     "2.124 \\times 10^{-6}"))))
 
+(ert-deftest litex-format-variable-test ()
+  (let ((litex-make-unicode-to-latex t)
+	(litex-make-name-to-latex-glyph t))
+    (should (string= (litex-format-variable 'α) "{\\alpha}"))
+    (should (string= (litex-format-variable 'α-β) "{\\alpha}_{{\\beta}}"))
+    (should (string= (litex-format-variable 'α-Δ/t-2)
+		     "{\\alpha}_{{\\Delta}t}_{2}"))
+    (should (string= (litex-format-variable '\\alpha) "\\alpha"))
+    (should (string= (litex-format-variable '\\alpha-\\beta) "\\alpha_{\\beta}"))
+    (should (string= (litex-format-variable '\\alpha-\\Delta\ t-2)
+		     "\\alpha_{\\Delta t}_{2}"))
+    (should (string= (litex-format-variable 'alpha) "{\\alpha}"))
+    (should (string= (litex-format-variable 'Delta/alpha)
+		     "{\\Delta}{\\alpha}"))
+    (should (string= (litex-format-variable 'alpha/beta)
+		     "{\\alpha}{\\beta}")))
+  )
+
+
 ;; individual operator tests
 (ert-deftest litex-format-args-+-test ()
     (should (string= (litex-format-args-+ '(1 2)) "1 + 2"))
@@ -99,6 +118,7 @@
   (should (string= (litex-lisp2latex-all
 		    '(setq x (- t 6 (* 5 60 (/ x)))))
 		   "x = t - 6 - 5 \\times 60\\left( \\frac1{x} \\right)"))
+  ;; this one is failing
   (should (string= (litex-lisp2latex-all
 		    '(setq x (- t 6 (* 5 60 (/ x 2)))))
 		   "x = t - 6 - 5 \\times 60\\left( \\frac{x}{2} \\right)"))

--- a/tests/litex-mode-tests.el
+++ b/tests/litex-mode-tests.el
@@ -76,9 +76,10 @@
     (should (string= (litex-format-args-/ '(1 2)) "\\frac{1}{2}"))
     (should (string= (litex-format-args-/ '(x 2)) "\\frac{x}{2}"))
     (should (string= (litex-format-args-/ '(1 y)) "\\frac{1}{y}"))
-    (should (string= (litex-format-args-/ '(1 2 y)) "\\frac{1}{2y}"))
-    (should (string= (litex-format-args-/
-		      '(1 2 y 3)) "\\frac{1}{2y \\times 3}"))
+    (should (string= (litex-format-args-/ '(1 2 y))
+		     "\\frac{1}{2y}"))
+    (should (string= (litex-format-args-/ '(1 2 y 3))
+		     "\\frac{1}{2y \\times 3}"))
     (should (string= (litex-format-args-/ '(x y)) "\\frac{x}{y}"))
     (should (string= (litex-format-args-/ '(2)) "\\frac1{2}"))
     (should (string= (litex-format-args-/ '(x)) "\\frac1{x}")))
@@ -117,15 +118,14 @@
   (should (string= (litex-lisp2latex-all '(1- (* 2 x))) "2x - 1"))
   (should (string= (litex-lisp2latex-all
 		    '(setq x (- t 6 (* 5 60 (/ x)))))
-		   "x = t - 6 - 5 \\times 60\\left( \\frac1{x} \\right)"))
+		   "x = t - 6 -  \\left( 5 \\times 60\\frac1{x} \\right) "))
   ;; this one is failing
   (should (string= (litex-lisp2latex-all
 		    '(setq x (- t 6 (* 5 60 (/ x 2)))))
-		   "x = t - 6 - 5 \\times 60\\frac{x}{2}"))
+		   "x = t - 6 -  \\left( 5 \\times 60 \\left( \\frac{x}{2} \\right)  \\right) "))
   (should (string= (litex-lisp2latex-all
 		    '(fun x 2 (/ 5 (+ 6 7) x)))
-		   "\\mathrm{fun}(x,2,\\frac{5}{\\left( 6 + 7 \\right)x})"))
-  )
+		   "\\text{fun}\\left(x,2,\\frac{5}{ \\left( 6 + 7 \\right) x}\\right)")))
 
 (litex-format-args-* '((+ 2 3) 1))
 

--- a/tests/litex-mode-tests.el
+++ b/tests/litex-mode-tests.el
@@ -27,25 +27,6 @@
     (should (string= (litex-format-float 2.1236e-6)
 		     "2.124 \\times 10^{-6}"))))
 
-(ert-deftest litex-format-variable-test ()
-  (let ((litex-make-unicode-to-latex t)
-	(litex-make-name-to-latex-glyph t))
-    (should (string= (litex-format-variable 'α) "{\\alpha}"))
-    (should (string= (litex-format-variable 'α-β) "{\\alpha}_{{\\beta}}"))
-    (should (string= (litex-format-variable 'α-Δ/t-2)
-		     "{\\alpha}_{{\\Delta}t}_{2}"))
-    (should (string= (litex-format-variable '\\alpha) "\\alpha"))
-    (should (string= (litex-format-variable '\\alpha-\\beta) "\\alpha_{\\beta}"))
-    (should (string= (litex-format-variable '\\alpha-\\Delta\ t-2)
-		     "\\alpha_{\\Delta t}_{2}"))
-    (should (string= (litex-format-variable 'alpha) "{\\alpha}"))
-    (should (string= (litex-format-variable 'Delta/alpha)
-		     "{\\Delta}{\\alpha}"))
-    (should (string= (litex-format-variable 'alpha/beta)
-		     "{\\alpha}{\\beta}")))
-  )
-
-
 ;; individual operator tests
 (ert-deftest litex-format-args-+-test ()
     (should (string= (litex-format-args-+ '(1 2)) "1 + 2"))
@@ -118,7 +99,6 @@
   (should (string= (litex-lisp2latex-all
 		    '(setq x (- t 6 (* 5 60 (/ x)))))
 		   "x = t - 6 - 5 \\times 60\\left( \\frac1{x} \\right)"))
-  ;; this one is failing
   (should (string= (litex-lisp2latex-all
 		    '(setq x (- t 6 (* 5 60 (/ x 2)))))
 		   "x = t - 6 - 5 \\times 60\\left( \\frac{x}{2} \\right)"))


### PR DESCRIPTION
Improve brackets logic to avoid mistake while also reducing redundant brackets
Add always enclose option to be able to override brackets logic and always insert it just to be safe.